### PR TITLE
feat(#7): 메뉴 관리 대시보드 UI 구현 완료

### DIFF
--- a/src/app/dashboard/menu/page.tsx
+++ b/src/app/dashboard/menu/page.tsx
@@ -1,4 +1,5 @@
 import CategoryManage from "@/components/layout/menu/CategoryManage";
+import MenuManage from "@/components/layout/menu/MenuManage";
 import TitleHeader from "@/components/ui/title/TitleHeader";
 
 export default function MenuPage() {
@@ -9,6 +10,7 @@ export default function MenuPage() {
         subText={"카테고리와 메뉴 그리고 옵션을 쉽게 추가하고 편집해보세요"}
       />
       <CategoryManage />
+      <MenuManage />
     </div>
   );
 }

--- a/src/app/dashboard/shop/page.tsx
+++ b/src/app/dashboard/shop/page.tsx
@@ -64,6 +64,7 @@ export default function ShopPage() {
                 setSearchQuery(e.target.value)
               }
               count={filteredShops.length}
+              placeholder="매장명, 주소, 전화번호로 검색..."
             />
           </div>
           <ViewMode

--- a/src/components/layout/menu/EmptyMenu.tsx
+++ b/src/components/layout/menu/EmptyMenu.tsx
@@ -1,0 +1,12 @@
+import InfoRoundedIcon from "@mui/icons-material/InfoRounded";
+const EmptyMenu = () => {
+  return (
+    <div className="text-center py-12">
+      <InfoRoundedIcon sx={{ fontSize: 48 }} className="mb-4 text-gray-700" />
+      <h3 className="text-lg font-medium text-gray-900 ">메뉴가 없습니다</h3>
+      <p className="text-gray-500">새로운 메뉴를 추가해보세요.</p>
+    </div>
+  );
+};
+
+export default EmptyMenu;

--- a/src/components/layout/menu/MenuCardGrid.tsx
+++ b/src/components/layout/menu/MenuCardGrid.tsx
@@ -1,0 +1,47 @@
+"use client";
+import MenuCard from "@/components/ui/card/MenuCard";
+import React from "react";
+import EmptyMenu from "./EmptyMenu";
+export interface MenuItem {
+  id: string;
+  name: string;
+  price: number;
+  description: string;
+  image: string;
+  optionCategories: string[];
+  isSoldOut: boolean;
+}
+
+interface MenuCardGridProps {
+  data: MenuItem[];
+  onEdit?: (id: string) => void;
+  onDelete?: (id: string) => void;
+  onToggleSoldOut?: (id: string) => void;
+}
+
+const MenuCardGrid: React.FC<MenuCardGridProps> = ({
+  data,
+  onEdit,
+  onDelete,
+  onToggleSoldOut,
+}) => {
+  if (data.length === 0) {
+    return <EmptyMenu />;
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 ">
+      {data.map((item) => (
+        <MenuCard
+          key={item.id}
+          item={item}
+          onEdit={onEdit}
+          onDelete={onDelete}
+          onToggleSoldOut={onToggleSoldOut}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default MenuCardGrid;

--- a/src/components/layout/menu/MenuListContainer.tsx
+++ b/src/components/layout/menu/MenuListContainer.tsx
@@ -1,0 +1,375 @@
+import React from "react";
+import {
+  Box,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  TableSortLabel,
+  Paper,
+  Chip,
+  IconButton,
+  Avatar,
+} from "@mui/material";
+import { Edit as EditIcon, Delete as DeleteIcon } from "@mui/icons-material";
+import { visuallyHidden } from "@mui/utils";
+import EmptyMenu from "./EmptyMenu";
+
+// MenuItem 타입 정의
+interface MenuItem {
+  id: string;
+  name: string;
+  price: number;
+  description: string;
+  image: string;
+  optionCategories: string[];
+  isSoldOut: boolean;
+}
+
+interface HeadCell {
+  id: keyof MenuItem | "actions";
+  label: string;
+}
+
+const headCells: readonly HeadCell[] = [
+  {
+    id: "name",
+    label: "메뉴명",
+  },
+  {
+    id: "price",
+    label: "가격",
+  },
+  {
+    id: "optionCategories",
+    label: "옵션",
+  },
+  {
+    id: "isSoldOut",
+    label: "상태",
+  },
+  {
+    id: "actions",
+    label: "작업",
+  },
+];
+
+// 정렬 함수들
+function descendingComparator<T>(a: T, b: T, orderBy: keyof T) {
+  if (b[orderBy] < a[orderBy]) {
+    return -1;
+  }
+  if (b[orderBy] > a[orderBy]) {
+    return 1;
+  }
+  return 0;
+}
+
+type Order = "asc" | "desc";
+
+function getComparator<T>(
+  order: Order,
+  orderBy: keyof T
+): (a: T, b: T) => number {
+  return order === "desc"
+    ? (a, b) => descendingComparator(a, b, orderBy)
+    : (a, b) => -descendingComparator(a, b, orderBy);
+}
+
+// 테이블 헤더 컴포넌트
+interface EnhancedTableProps {
+  onRequestSort: (
+    event: React.MouseEvent<unknown>,
+    property: keyof MenuItem
+  ) => void;
+  order: Order;
+  orderBy: string;
+  rowCount: number;
+}
+
+function EnhancedTableHead(props: EnhancedTableProps) {
+  const { order, orderBy, onRequestSort } = props;
+  const createSortHandler =
+    (property: keyof MenuItem) => (event: React.MouseEvent<unknown>) => {
+      onRequestSort(event, property);
+    };
+
+  return (
+    <TableHead>
+      <TableRow>
+        {headCells.map((headCell) => (
+          <TableCell
+            key={headCell.id}
+            align="center"
+            sortDirection={orderBy === headCell.id ? order : false}
+            sx={{ paddingLeft: 5 }}
+          >
+            {headCell.id !== "actions" ? (
+              <TableSortLabel
+                active={orderBy === headCell.id}
+                direction={orderBy === headCell.id ? order : "asc"}
+                onClick={createSortHandler(headCell.id as keyof MenuItem)}
+              >
+                {headCell.label}
+                {orderBy === headCell.id ? (
+                  <Box component="span" sx={visuallyHidden}>
+                    {order === "desc"
+                      ? "sorted descending"
+                      : "sorted ascending"}
+                  </Box>
+                ) : null}
+              </TableSortLabel>
+            ) : (
+              headCell.label
+            )}
+          </TableCell>
+        ))}
+      </TableRow>
+    </TableHead>
+  );
+}
+
+// Props 타입 정의
+interface MenuListContainerProps {
+  data: MenuItem[];
+}
+
+const MenuListContainer = ({ data }: MenuListContainerProps) => {
+  if (data.length === 0) {
+    return <EmptyMenu />;
+  }
+  // 받은 데이터를 그대로 사용
+  const menuItems: MenuItem[] = React.useMemo(() => {
+    return data;
+  }, [data]);
+
+  const [order, setOrder] = React.useState<Order>("asc");
+  const [orderBy, setOrderBy] = React.useState<keyof MenuItem>("name");
+  const [page, setPage] = React.useState(0);
+  const [rowsPerPage, setRowsPerPage] = React.useState(5);
+
+  const handleRequestSort = (
+    event: React.MouseEvent<unknown>,
+    property: keyof MenuItem
+  ) => {
+    const isAsc = orderBy === property && order === "asc";
+    setOrder(isAsc ? "desc" : "asc");
+    setOrderBy(property);
+  };
+
+  const handleChangePage = (event: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  const handleEdit = (id: string) => {
+    console.log("Edit menu:", id);
+  };
+
+  const handleDelete = (id: string) => {
+    console.log("Delete menu:", id);
+  };
+
+  const handleToggleSoldOut = (id: string) => {
+    console.log("Toggle sold out:", id);
+  };
+
+  const formatPrice = (price: number) => {
+    return new Intl.NumberFormat("ko-KR").format(price);
+  };
+
+  const visibleRows = React.useMemo(
+    () =>
+      [...menuItems]
+        .sort(getComparator(order, orderBy))
+        .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage),
+    [order, orderBy, page, rowsPerPage, menuItems]
+  );
+  const emptyRows =
+    visibleRows.length < rowsPerPage ? rowsPerPage - visibleRows.length : 0;
+
+  return (
+    <Box sx={{ width: "100%" }}>
+      <Paper sx={{ width: "100%", mb: 2 }}>
+        <TableContainer>
+          <Table
+            stickyHeader
+            aria-label="menu table"
+            sx={{ minWidth: 750 }}
+            size="medium"
+          >
+            <EnhancedTableHead
+              order={order}
+              orderBy={orderBy}
+              onRequestSort={handleRequestSort}
+              rowCount={menuItems.length}
+            />
+            <TableBody>
+              {visibleRows.map((row, index) => {
+                const labelId = `enhanced-table-checkbox-${index}`;
+
+                return (
+                  <TableRow
+                    hover
+                    tabIndex={-1}
+                    key={row.id}
+                    sx={{ cursor: "pointer" }}
+                  >
+                    <TableCell component="th" id={labelId} align="center">
+                      <Box
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 2,
+                          justifyContent: "center",
+                        }}
+                      >
+                        <Avatar
+                          src={row.image || ""}
+                          alt={row.name}
+                          sx={{ width: 40, height: 40 }}
+                        >
+                          {!row.image && row.name.charAt(0)}
+                        </Avatar>
+                        <Box sx={{ textAlign: "left" }}>
+                          <Box sx={{ fontWeight: 600, mb: 0.5 }}>
+                            {row.name}
+                          </Box>
+                          <Box
+                            sx={{
+                              fontSize: "0.875rem",
+                              color: "text.secondary",
+                              maxWidth: 200,
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              whiteSpace: "nowrap",
+                            }}
+                          >
+                            {row.description}
+                          </Box>
+                        </Box>
+                      </Box>
+                    </TableCell>
+                    <TableCell align="center">
+                      <Box sx={{ fontWeight: 600, color: "primary.main" }}>
+                        ₩{formatPrice(row.price)}
+                      </Box>
+                    </TableCell>
+                    <TableCell align="center">
+                      {row.optionCategories.length > 0 ? (
+                        <Box
+                          sx={{
+                            mt: 0.5,
+                            display: "flex",
+                            gap: 0.5,
+                            flexWrap: "wrap",
+                            justifyContent: "center",
+                          }}
+                        >
+                          {row.optionCategories
+                            .slice(0, 2)
+                            .map((option, idx) => (
+                              <Chip
+                                key={idx}
+                                label={option}
+                                size="small"
+                                variant="outlined"
+                                sx={{ fontSize: "0.75rem", height: 20 }}
+                              />
+                            ))}
+                          {row.optionCategories.length > 2 && (
+                            <Chip
+                              label={`+${row.optionCategories.length - 2}`}
+                              size="small"
+                              variant="outlined"
+                              sx={{ fontSize: "0.75rem", height: 20 }}
+                            />
+                          )}
+                        </Box>
+                      ) : (
+                        <span className=" text-slate-500 text-xs">
+                          옵션없음
+                        </span>
+                      )}
+                    </TableCell>
+                    <TableCell align="center">
+                      <Chip
+                        label={row.isSoldOut ? "품절" : "판매중"}
+                        size="small"
+                        color={row.isSoldOut ? "error" : "success"}
+                        variant="filled"
+                      />
+                    </TableCell>
+                    <TableCell align="center">
+                      <Box
+                        sx={{
+                          display: "flex",
+                          gap: 0.5,
+                          justifyContent: "center",
+                        }}
+                      >
+                        <IconButton
+                          size="small"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleEdit(row.id);
+                          }}
+                          sx={{ color: "primary.main" }}
+                        >
+                          <EditIcon fontSize="small" />
+                        </IconButton>
+                        <IconButton
+                          size="small"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleDelete(row.id);
+                          }}
+                          sx={{ color: "error.main" }}
+                        >
+                          <DeleteIcon fontSize="small" />
+                        </IconButton>
+                      </Box>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+              {emptyRows > 0 && (
+                <TableRow
+                  style={{
+                    height: 101 * emptyRows,
+                  }}
+                >
+                  <TableCell colSpan={4} />
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <TablePagination
+          rowsPerPageOptions={[5, 10, 25]}
+          component="div"
+          count={menuItems.length}
+          rowsPerPage={rowsPerPage}
+          page={page}
+          onPageChange={handleChangePage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+          labelRowsPerPage="페이지당 행 수:"
+          labelDisplayedRows={({ from, to, count }) =>
+            `${count}개 중 ${from}-${to}`
+          }
+        />
+      </Paper>
+    </Box>
+  );
+};
+
+export default MenuListContainer;

--- a/src/components/layout/menu/MenuManage.tsx
+++ b/src/components/layout/menu/MenuManage.tsx
@@ -1,0 +1,165 @@
+// "use client";
+// import SearchBar from "@/components/ui/card/SearchBar";
+// import ViewMode from "@/components/ui/card/ViewMode";
+// import { SectionTitle } from "@/components/ui/title/SectionTitle";
+// import React, { useState } from "react";
+
+// const MenuManage = () => {
+//   const [searchQuery, setSearchQuery] = useState("");
+//   const [viewMode, setViewMode] = useState<"card" | "list">("card");
+
+//   return (
+//     <div className="bg-white rounded-xl p-6 shadow-sm mb-6">
+//       <SectionTitle
+//         title={"메뉴 관리"}
+//         subText={"클릭하여 수정/삭제를 하고 드래그 드롭으로 순서를 바꿔보세요"}
+//         buttonText="+ 메뉴 추가"
+//         buttonClassName="px-3 py-2 text-sm"
+//         buttonClick={() => {}}
+//       />
+
+//       <div className="bg-white rounded-xl p-6  mb-6">
+//         <div className="flex flex-col sm:flex-row gap-4 items-start  justify-between">
+//           <div className="flex-1">
+//             <SearchBar
+//               searchQuery={searchQuery}
+//               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+//                 setSearchQuery(e.target.value)
+//               }
+//               count={0}
+//               placeholder={"메뉴 관련 정보로 검색해 보세요"}
+//             />
+//           </div>
+//           <ViewMode
+//             viewMode={viewMode}
+//             onCardClick={() => setViewMode("card")}
+//             onListClick={() => setViewMode("list")}
+//           />
+//         </div>
+//       </div>
+//     </div>
+//   );
+// };
+
+// export default MenuManage;
+"use client";
+import SearchBar from "@/components/ui/card/SearchBar";
+import ViewMode from "@/components/ui/card/ViewMode";
+import { SectionTitle } from "@/components/ui/title/SectionTitle";
+import MenuCardGrid from "./MenuCardGrid";
+import { mockMenuData } from "./mockMenuData";
+import React, { useState, useMemo } from "react";
+import MenuListContainer from "./MenuListContainer";
+
+const MenuManage = () => {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [viewMode, setViewMode] = useState<"card" | "list">("card");
+  const [selectedCategory, setSelectedCategory] = useState<string>("전체");
+
+  // 현재 선택된 카테고리의 메뉴들
+  const currentMenus = useMemo(() => {
+    if (selectedCategory === "전체") {
+      return Object.values(mockMenuData.data.menusByCategory).flat();
+    }
+    return mockMenuData.data.menusByCategory[selectedCategory] || [];
+  }, [selectedCategory]);
+
+  // 검색 필터링된 메뉴들
+  const filteredMenus = useMemo(() => {
+    if (!searchQuery.trim()) return currentMenus;
+
+    return currentMenus.filter(
+      (menu) =>
+        menu.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        menu.description.toLowerCase().includes(searchQuery.toLowerCase())
+    );
+  }, [currentMenus, searchQuery]);
+
+  const handleEdit = (id: string) => {
+    console.log("Edit menu:", id);
+  };
+
+  const handleDelete = (id: string) => {
+    console.log("Delete menu:", id);
+  };
+
+  const handleToggleSoldOut = (id: string) => {
+    console.log("Toggle sold out:", id);
+  };
+  console.log("filteredMenusfilteredMenus", filteredMenus);
+  return (
+    <div className="bg-white rounded-xl p-6 shadow-sm mb-6">
+      <SectionTitle
+        title={"메뉴 관리"}
+        subText={"클릭하여 수정/삭제를 하고 드래그 드롭으로 순서를 바꿔보세요"}
+        buttonText="+ 메뉴 추가"
+        buttonClassName="px-3 py-2 text-sm"
+        buttonClick={() => {}}
+      />
+
+      <div className="bg-white rounded-xl p-6 mb-6">
+        <div className="flex flex-col sm:flex-row gap-4 items-start justify-between">
+          <div className="flex-1">
+            <SearchBar
+              searchQuery={searchQuery}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setSearchQuery(e.target.value)
+              }
+              count={filteredMenus.length}
+              placeholder={"메뉴 관련 정보로 검색해 보세요"}
+            />
+          </div>
+          <ViewMode
+            viewMode={viewMode}
+            onCardClick={() => setViewMode("card")}
+            onListClick={() => setViewMode("list")}
+          />
+        </div>
+      </div>
+
+      {/* 카테고리 탭 */}
+      <div className="mb-6">
+        <div className="flex gap-2 flex-wrap">
+          <button
+            onClick={() => setSelectedCategory("전체")}
+            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+              selectedCategory === "전체"
+                ? "bg-blue-500 text-white"
+                : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+            }`}
+          >
+            전체
+          </button>
+          {mockMenuData.data.categories.map((category) => (
+            <button
+              key={category}
+              onClick={() => setSelectedCategory(category)}
+              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                selectedCategory === category
+                  ? "bg-blue-500 text-white"
+                  : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+              }`}
+            >
+              {category}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* 메뉴 카드 그리드 */}
+      {viewMode === "card" && (
+        <MenuCardGrid
+          data={filteredMenus}
+          onEdit={handleEdit}
+          onDelete={handleDelete}
+          onToggleSoldOut={handleToggleSoldOut}
+        />
+      )}
+
+      {/* 리스트 뷰는 여기에 추가 */}
+      {viewMode === "list" && <MenuListContainer data={filteredMenus} />}
+    </div>
+  );
+};
+
+export default MenuManage;

--- a/src/components/layout/menu/mockMenuData.ts
+++ b/src/components/layout/menu/mockMenuData.ts
@@ -1,0 +1,155 @@
+export interface MenuItem {
+  id: string;
+  name: string;
+  price: number;
+  description: string;
+  image: string;
+  optionCategories: string[];
+  isSoldOut: boolean;
+}
+
+export interface MenuData {
+  success: boolean;
+  code: number;
+  message: string;
+  data: {
+    categories: string[];
+    menusByCategory: {
+      [category: string]: MenuItem[];
+    };
+  };
+}
+export const mockMenuData: MenuData = {
+  success: true,
+  code: 0,
+  message: "메뉴 조회 성공",
+  data: {
+    categories: ["커피", "차", "디저트", "베이커리", "스무디"],
+    menusByCategory: {
+      커피: [
+        {
+          id: "coffee_001",
+          name: "아메리카노",
+          price: 4500,
+          description:
+            "진한 에스프레소와 뜨거운 물로 만든 클래식 커피입니다. 깔끔하고 진한 맛이 특징입니다.",
+          image:
+            "https://images.unsplash.com/photo-1509042239860-f550ce710b93?w=400",
+          optionCategories: ["사이즈", "온도", "샷추가"],
+          isSoldOut: false,
+        },
+        {
+          id: "coffee_002",
+          name: "카페라떼",
+          price: 5000,
+          description:
+            "부드러운 스팀 밀크와 에스프레소의 완벽한 조화로 만든 라떼입니다.",
+          image:
+            "https://images.unsplash.com/photo-1570968915860-54d5c301fa9f?w=400",
+          optionCategories: ["사이즈", "온도", "시럽"],
+          isSoldOut: false,
+        },
+        {
+          id: "coffee_003",
+          name: "카푸치노",
+          price: 5500,
+          description:
+            "풍성한 우유 거품과 에스프레소가 만나는 이탈리안 스타일 커피입니다.",
+          image: "",
+          optionCategories: ["사이즈", "온도"],
+          isSoldOut: true,
+        },
+        {
+          id: "coffee_004",
+          name: "바닐라 라떼",
+          price: 5500,
+          description:
+            "달콤한 바닐라 시럽이 들어간 부드러운 라떼로 달콤함을 원하는 분께 추천합니다.",
+          image:
+            "https://images.unsplash.com/photo-1461023058943-07fcbe16d735?w=400",
+          optionCategories: ["사이즈", "온도", "시럽농도"],
+          isSoldOut: false,
+        },
+        {
+          id: "coffee_005",
+          name: "카라멜 마키아토",
+          price: 6000,
+          description:
+            "부드러운 스팀 밀크 위에 카라멜 드리즐을 올린 달콤한 커피입니다.",
+          image:
+            "https://images.unsplash.com/photo-1541167760496-1628856ab772?w=400",
+          optionCategories: ["사이즈", "온도", "카라멜추가"],
+          isSoldOut: false,
+        },
+      ],
+      차: [
+        {
+          id: "tea_001",
+          name: "얼그레이",
+          price: 4000,
+          description: "베르가못 향이 특징인 영국 전통 홍차입니다.",
+          image: "",
+          optionCategories: ["온도", "당도"],
+          isSoldOut: false,
+        },
+        {
+          id: "tea_002",
+          name: "캐모마일",
+          price: 4500,
+          description: "은은한 꽃향기와 편안한 맛의 허브티입니다.",
+          image:
+            "https://images.unsplash.com/photo-1556881286-fc6915169721?w=400",
+          optionCategories: ["온도", "꿀추가"],
+          isSoldOut: false,
+        },
+      ],
+      디저트: [
+        {
+          id: "dessert_001",
+          name: "티라미수",
+          price: 6500,
+          description:
+            "이탈리아 전통 디저트로 마스카포네 치즈와 에스프레소의 조화가 일품입니다.",
+          image:
+            "https://images.unsplash.com/photo-1571877227200-a0d98ea607e9?w=400",
+          optionCategories: [],
+          isSoldOut: false,
+        },
+        {
+          id: "dessert_002",
+          name: "초콜릿 케이크",
+          price: 5500,
+          description:
+            "진한 초콜릿의 맛과 부드러운 식감이 매력적인 케이크입니다.",
+          image:
+            "https://images.unsplash.com/photo-1578985545062-69928b1d9587?w=400",
+          optionCategories: ["사이즈"],
+          isSoldOut: false,
+        },
+      ],
+      베이커리: [
+        {
+          id: "bakery_001",
+          name: "크루아상",
+          price: 3500,
+          description: "바삭하고 부드러운 프랑스 전통 페이스트리입니다.",
+          image: "",
+          optionCategories: ["토핑"],
+          isSoldOut: false,
+        },
+      ],
+      스무디: [
+        {
+          id: "smoothie_001",
+          name: "딸기 바나나 스무디",
+          price: 6000,
+          description: "신선한 딸기와 바나나로 만든 건강한 스무디입니다.",
+          image:
+            "https://images.unsplash.com/photo-1553530666-ba11a7da3888?w=400",
+          optionCategories: ["사이즈", "당도조절"],
+          isSoldOut: false,
+        },
+      ],
+    },
+  },
+};

--- a/src/components/layout/menu/mockMenuData.ts
+++ b/src/components/layout/menu/mockMenuData.ts
@@ -19,6 +19,140 @@ export interface MenuData {
     };
   };
 }
+// export const mockMenuData: MenuData = {
+//   success: true,
+//   code: 0,
+//   message: "메뉴 조회 성공",
+//   data: {
+//     categories: ["커피", "차", "디저트", "베이커리", "스무디"],
+//     menusByCategory: {
+//       커피: [
+//         {
+//           id: "coffee_001",
+//           name: "아메리카노",
+//           price: 4500,
+//           description:
+//             "진한 에스프레소와 뜨거운 물로 만든 클래식 커피입니다. 깔끔하고 진한 맛이 특징입니다.",
+//           image:
+//             "https://images.unsplash.com/photo-1509042239860-f550ce710b93?w=400",
+//           optionCategories: ["사이즈", "온도", "샷추가"],
+//           isSoldOut: false,
+//         },
+//         {
+//           id: "coffee_002",
+//           name: "카페라떼",
+//           price: 5000,
+//           description:
+//             "부드러운 스팀 밀크와 에스프레소의 완벽한 조화로 만든 라떼입니다.",
+//           image:
+//             "https://images.unsplash.com/photo-1570968915860-54d5c301fa9f?w=400",
+//           optionCategories: ["사이즈", "온도", "시럽"],
+//           isSoldOut: false,
+//         },
+//         {
+//           id: "coffee_003",
+//           name: "카푸치노",
+//           price: 5500,
+//           description:
+//             "풍성한 우유 거품과 에스프레소가 만나는 이탈리안 스타일 커피입니다.",
+//           image: "",
+//           optionCategories: ["사이즈", "온도"],
+//           isSoldOut: true,
+//         },
+//         {
+//           id: "coffee_004",
+//           name: "바닐라 라떼",
+//           price: 5500,
+//           description:
+//             "달콤한 바닐라 시럽이 들어간 부드러운 라떼로 달콤함을 원하는 분께 추천합니다.",
+//           image:
+//             "https://images.unsplash.com/photo-1461023058943-07fcbe16d735?w=400",
+//           optionCategories: ["사이즈", "온도", "시럽농도"],
+//           isSoldOut: false,
+//         },
+//         {
+//           id: "coffee_005",
+//           name: "카라멜 마키아토",
+//           price: 6000,
+//           description:
+//             "부드러운 스팀 밀크 위에 카라멜 드리즐을 올린 달콤한 커피입니다.",
+//           image:
+//             "https://images.unsplash.com/photo-1541167760496-1628856ab772?w=400",
+//           optionCategories: ["사이즈", "온도", "카라멜추가"],
+//           isSoldOut: false,
+//         },
+//       ],
+//       차: [
+//         {
+//           id: "tea_001",
+//           name: "얼그레이",
+//           price: 4000,
+//           description: "베르가못 향이 특징인 영국 전통 홍차입니다.",
+//           image: "",
+//           optionCategories: ["온도", "당도"],
+//           isSoldOut: false,
+//         },
+//         {
+//           id: "tea_002",
+//           name: "캐모마일",
+//           price: 4500,
+//           description: "은은한 꽃향기와 편안한 맛의 허브티입니다.",
+//           image:
+//             "https://images.unsplash.com/photo-1556881286-fc6915169721?w=400",
+//           optionCategories: ["온도", "꿀추가"],
+//           isSoldOut: false,
+//         },
+//       ],
+//       디저트: [
+//         {
+//           id: "dessert_001",
+//           name: "티라미수",
+//           price: 6500,
+//           description:
+//             "이탈리아 전통 디저트로 마스카포네 치즈와 에스프레소의 조화가 일품입니다.",
+//           image:
+//             "https://images.unsplash.com/photo-1571877227200-a0d98ea607e9?w=400",
+//           optionCategories: [],
+//           isSoldOut: false,
+//         },
+//         {
+//           id: "dessert_002",
+//           name: "초콜릿 케이크",
+//           price: 5500,
+//           description:
+//             "진한 초콜릿의 맛과 부드러운 식감이 매력적인 케이크입니다.",
+//           image:
+//             "https://images.unsplash.com/photo-1578985545062-69928b1d9587?w=400",
+//           optionCategories: ["사이즈"],
+//           isSoldOut: false,
+//         },
+//       ],
+//       베이커리: [
+//         {
+//           id: "bakery_001",
+//           name: "크루아상",
+//           price: 3500,
+//           description: "바삭하고 부드러운 프랑스 전통 페이스트리입니다.",
+//           image: "",
+//           optionCategories: ["토핑"],
+//           isSoldOut: false,
+//         },
+//       ],
+//       스무디: [
+//         {
+//           id: "smoothie_001",
+//           name: "딸기 바나나 스무디",
+//           price: 6000,
+//           description: "신선한 딸기와 바나나로 만든 건강한 스무디입니다.",
+//           image:
+//             "https://images.unsplash.com/photo-1553530666-ba11a7da3888?w=400",
+//           optionCategories: ["사이즈", "당도조절"],
+//           isSoldOut: false,
+//         },
+//       ],
+//     },
+//   },
+// };
 export const mockMenuData: MenuData = {
   success: true,
   code: 0,

--- a/src/components/ui/card/MenuCard.tsx
+++ b/src/components/ui/card/MenuCard.tsx
@@ -1,0 +1,121 @@
+"use client";
+import React from "react";
+export interface MenuItem {
+  id: string;
+  name: string;
+  price: number;
+  description: string;
+  image: string;
+  optionCategories: string[];
+  isSoldOut: boolean;
+}
+
+interface MenuCardProps {
+  item: MenuItem;
+  onEdit?: (id: string) => void;
+  onDelete?: (id: string) => void;
+  onToggleSoldOut?: (id: string) => void;
+}
+
+const MenuCard: React.FC<MenuCardProps> = ({
+  item,
+  onEdit,
+  onDelete,
+  onToggleSoldOut,
+}) => {
+  const formatPrice = (price: number) => {
+    return new Intl.NumberFormat("ko-KR").format(price);
+  };
+
+  return (
+    <div className="bg-white rounded-xl p-5 shadow-sm border border-gray-100 hover:shadow-md transition-all duration-200 hover:transform hover:-translate-y-1">
+      {/* 메뉴 이미지 */}
+      <div className="relative mb-4">
+        <div className="w-full h-40 bg-gray-100 rounded-lg overflow-hidden">
+          {item.image ? (
+            <img
+              src={item.image}
+              alt={item.name}
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center text-gray-400">
+              이미지 없음
+            </div>
+          )}
+        </div>
+
+        {/* 품절 배지 */}
+        {item.isSoldOut && (
+          <div className="absolute top-2 right-2 bg-red-500 text-white px-2 py-1 rounded-md text-xs font-medium">
+            품절
+          </div>
+        )}
+      </div>
+
+      {/* 메뉴 정보 */}
+      <div className="mb-4">
+        <div className="flex items-start justify-between mb-2">
+          <h3 className="text-lg font-semibold text-gray-900 line-clamp-1">
+            {item.name}
+          </h3>
+          <span className="text-lg font-bold text-blue-600 ml-2">
+            ₩{formatPrice(item.price)}
+          </span>
+        </div>
+
+        <p className="text-sm text-gray-600 line-clamp-2 mb-3">
+          {item.description}
+        </p>
+
+        {/* 옵션 카테고리 */}
+        {item.optionCategories.length > 0 ? (
+          <div className="mb-3">
+            <div className="flex flex-wrap gap-1">
+              {item.optionCategories.map((option, index) => (
+                <span
+                  key={index}
+                  className="inline-block bg-gray-100 text-gray-700 px-2 py-1 rounded-md text-xs"
+                >
+                  {option}
+                </span>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="mb-4">
+            <span className="inline-block px-2 py-1 rounded-md text-xs"></span>
+          </div>
+        )}
+      </div>
+
+      {/* 액션 버튼들 */}
+      <div className="flex gap-2 pt-3 border-t border-gray-100">
+        <button
+          onClick={() => onEdit?.(item.id)}
+          className="flex-1 px-3 py-2 text-sm font-medium text-gray-700 bg-gray-50 hover:bg-gray-100 rounded-lg transition-colors"
+        >
+          수정
+        </button>
+        <button
+          onClick={() => onToggleSoldOut?.(item.id)}
+          className={`flex-1 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${
+            item.isSoldOut
+              ? "text-green-700 bg-green-50 hover:bg-green-100"
+              : "text-orange-700 bg-orange-50 hover:bg-orange-100"
+          }`}
+        >
+          {item.isSoldOut ? "판매시작" : "품절처리"}
+        </button>
+        <button
+          onClick={() => onDelete?.(item.id)}
+          className="px-3 py-2 text-sm font-medium text-red-700 bg-red-50 hover:bg-red-100 rounded-lg transition-colors"
+        >
+          삭제
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default MenuCard;

--- a/src/components/ui/card/SearchBar.tsx
+++ b/src/components/ui/card/SearchBar.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import SearchIcon from "../icon/SearchIcon";
 interface SearchBarProps {
   searchQuery: string;
+  placeholder?: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   count: number;
 }
@@ -9,6 +10,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
   searchQuery,
   onChange,
   count,
+  placeholder,
 }) => {
   return (
     <>
@@ -19,7 +21,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
         </div>
         <input
           type="text"
-          placeholder="매장명, 주소, 전화번호로 검색..."
+          placeholder={placeholder || ""}
           value={searchQuery}
           onChange={onChange}
           className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"


### PR DESCRIPTION
# feat(#7): 메뉴 관리 대시보드 UI 구현 완료

- 메뉴 관리 대시보드에서 카테고리를 제외한 메뉴관련 구현

## 작업내용

- 카드 컴포넌트 구현
- 카드 그리드 컴포넌트 구현
- 카드 table 컴포넌트 구현
- 빈 메뉴 컴포넌트 구현
- 메뉴 검색바 연결 및 카테고리 별 filter기능 추가

## 이미지 첨부

<img width="1499" height="733" alt="image" src="https://github.com/user-attachments/assets/d3bb9598-fec9-412c-a9a1-c996e66ebca2" />
<img width="1508" height="755" alt="image" src="https://github.com/user-attachments/assets/8c200979-7302-48d7-8d95-2775dbaba795" />


## 관련이슈

Closes #7
