### PR TITLE
feat(#10): 메뉴 관리 대시보드 & 옵션관리 대시보드 CRUD 및 api 연결

### DIFF
--- a/src/app/dashboard/option/page.tsx
+++ b/src/app/dashboard/option/page.tsx
@@ -1,3 +1,14 @@
+import OptionManage from "@/components/layout/option/OptionManage";
+import TitleHeader from "@/components/ui/title/TitleHeader";
+
 export default function OptionPage() {
-  return <div>매출 통계</div>;
+  return (
+    <div className="max-w-8xl mx-auto p-2">
+      <TitleHeader
+        title={"옵션 관리"}
+        subText={"메뉴 옵션 그룹과 개별 옵션을 관리하고 가격을 설정하세요"}
+      />
+      <OptionManage />
+    </div>
+  );
 }

--- a/src/app/dashboard/option/page.tsx
+++ b/src/app/dashboard/option/page.tsx
@@ -1,0 +1,3 @@
+export default function OptionPage() {
+  return <div>매출 통계</div>;
+}

--- a/src/app/dashboard/statistics/page.tsx
+++ b/src/app/dashboard/statistics/page.tsx
@@ -1,3 +1,0 @@
-export default function StatisticsPage() {
-  return <div>매출 통계</div>;
-}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -40,6 +40,10 @@
   /* 기본 스타일 설정 */
   * {
     @apply border-border;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
   }
 
   body {

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -8,11 +8,11 @@ export default function Sidebar() {
 
   const menuItems = [
     { href: "/dashboard", label: "대시보드" },
-    { href: "/dashboard/menu", label: "메뉴 관리" },
     { href: "/dashboard/shop", label: "매장 관리" },
+    { href: "/dashboard/menu", label: "메뉴 관리" },
+    { href: "/dashboard/option", label: "옵션 관리" },
     { href: "/dashboard/orders", label: "주문 관리" },
-    { href: "/dashboard/statistics", label: "매출 통계" },
-    { href: "/dashboard/settings", label: "설정" },
+    // { href: "/dashboard/settings", label: "설정" },
   ];
 
   return (

--- a/src/components/layout/menu/MenuListContainer.tsx
+++ b/src/components/layout/menu/MenuListContainer.tsx
@@ -17,7 +17,7 @@ import {
 import { Edit as EditIcon, Delete as DeleteIcon } from "@mui/icons-material";
 import { visuallyHidden } from "@mui/utils";
 import EmptyMenu from "./EmptyMenu";
-import { MenuItem } from "@/lib/store/MenuStore";
+import { MenuItem, useMenuStore } from "@/lib/store/MenuStore";
 import MenuFormModal from "../modal/MenuFormModal";
 
 interface HeadCell {
@@ -35,7 +35,7 @@ const headCells: readonly HeadCell[] = [
     label: "가격",
   },
   {
-    id: "optionCategories",
+    id: "optionCategoryIds",
     label: "옵션",
   },
   {
@@ -187,7 +187,11 @@ const MenuListContainer = ({ data, onDelete }: MenuListContainerProps) => {
   );
   const emptyRows =
     visibleRows.length < rowsPerPage ? rowsPerPage - visibleRows.length : 0;
-
+  const { optionCategories: optionData } = useMenuStore();
+  const findOptionName = (id: string) => {
+    const result = optionData.find((ele) => ele.id === Number(id));
+    return result?.name || null;
+  };
   if (data.length === 0) {
     return <EmptyMenu />;
   }
@@ -219,13 +223,14 @@ const MenuListContainer = ({ data, onDelete }: MenuListContainerProps) => {
                       key={row.id}
                       sx={{ cursor: "pointer" }}
                     >
-                      <TableCell component="th" id={labelId} align="center">
+                      <TableCell component="th" id={labelId} align="left">
                         <Box
                           sx={{
                             display: "flex",
                             alignItems: "center",
                             gap: 2,
-                            justifyContent: "center",
+                            justifyContent: "left",
+                            marginLeft: "30px",
                           }}
                         >
                           <Avatar
@@ -260,7 +265,7 @@ const MenuListContainer = ({ data, onDelete }: MenuListContainerProps) => {
                         </Box>
                       </TableCell>
                       <TableCell align="center">
-                        {row?.optionCategories?.length > 0 ? (
+                        {row?.optionCategoryIds?.length > 0 ? (
                           <Box
                             sx={{
                               mt: 0.5,
@@ -270,20 +275,20 @@ const MenuListContainer = ({ data, onDelete }: MenuListContainerProps) => {
                               justifyContent: "center",
                             }}
                           >
-                            {row?.optionCategories
+                            {row?.optionCategoryIds
                               .slice(0, 2)
                               .map((option, idx) => (
                                 <Chip
                                   key={idx}
-                                  label={option}
+                                  label={findOptionName(option)}
                                   size="small"
                                   variant="outlined"
                                   sx={{ fontSize: "0.75rem", height: 20 }}
                                 />
                               ))}
-                            {row?.optionCategories?.length > 2 && (
+                            {row?.optionCategoryIds?.length > 2 && (
                               <Chip
-                                label={`+${row.optionCategories.length - 2}`}
+                                label={`+${row.optionCategoryIds.length - 2}`}
                                 size="small"
                                 variant="outlined"
                                 sx={{ fontSize: "0.75rem", height: 20 }}

--- a/src/components/layout/menu/MenuManage.tsx
+++ b/src/components/layout/menu/MenuManage.tsx
@@ -105,7 +105,7 @@ const MenuManage = () => {
       price: currentMenu.price,
       description: currentMenu.description,
       categoryId: categoryId || "",
-      optionCategories: currentMenu.optionCategories || [],
+      optionCategories: currentMenu.optionCategoryIds || [],
       isSoldOut: newSoldOutStatus, // 토글된 상태
     };
     console.log("품절처리", requestData);

--- a/src/components/layout/modal/MenuFormModal.tsx
+++ b/src/components/layout/modal/MenuFormModal.tsx
@@ -1,3 +1,469 @@
+// import ClosedIcon from "@/components/ui/icon/ClosedIcon";
+// import AcceptButton from "@/components/ui/button/AcceptButton";
+// import CancelButton from "@/components/ui/button/CancelButton";
+// import React, { useState, useEffect } from "react";
+// import { useMenuStore, MenuItem } from "@/lib/store/MenuStore";
+// import { useMutation, useQueryClient } from "@tanstack/react-query";
+// import { menuAPI } from "@/lib/api/menu";
+// import { useShopStore } from "@/lib/store/shopStore";
+// import { useNotification } from "@/hooks/useNotification";
+
+// interface MenuFormModalProps {
+//   isOpen: boolean;
+//   onClose: () => void;
+//   onConfirm: () => void;
+//   mode: "create" | "update";
+//   editMenu?: MenuItem | null;
+// }
+
+// const MenuFormModal: React.FC<MenuFormModalProps> = ({
+//   isOpen,
+//   onClose,
+//   onConfirm,
+//   mode,
+//   editMenu,
+// }) => {
+//   const queryClient = useQueryClient();
+//   const [menuData, setMenuData] = useState({
+//     name: "",
+//     price: "",
+//     description: "",
+//     category: "",
+//     optionCategories: [] as string[],
+//     isSoldOut: false,
+//   });
+//   const [imageFile, setImageFile] = useState<File | null>(null);
+//   const [imagePreview, setImagePreview] = useState<string | null>(null);
+//   const [isDragOver, setIsDragOver] = useState(false);
+
+//   const { choosedShop } = useShopStore();
+//   const { categories, optionCategories: optionData } = useMenuStore();
+
+//   // 수정 모드일 때 기존 데이터로 폼 초기화
+//   useEffect(() => {
+//     if (mode === "update" && editMenu && isOpen) {
+//       setMenuData({
+//         name: editMenu.name,
+//         price: editMenu.price.toString(),
+//         description: editMenu.description,
+//         category: editMenu.categoryId || "",
+//         optionCategories: editMenu.optionCategories,
+//         isSoldOut: editMenu.isSoldOut,
+//       });
+
+//       // 기존 이미지가 있으면 미리보기 설정
+//       if (editMenu.imageUrl) {
+//         setImagePreview(editMenu.imageUrl);
+//       }
+//     } else if (mode === "create") {
+//       // 생성 모드일 때는 초기화
+//       handleReset();
+//     }
+//   }, [mode, editMenu, isOpen]);
+//   useEffect(() => {
+//     console.log(menuData);
+//     console.log(menuData);
+//     console.log(menuData);
+//     console.log(menuData);
+//     console.log(menuData);
+//   }, [menuData]);
+//   const handleInputChange = (
+//     e: React.ChangeEvent<
+//       HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+//     >
+//   ) => {
+//     const { name, value, type } = e.target;
+//     if (type === "checkbox") {
+//       const checked = (e.target as HTMLInputElement).checked;
+//       setMenuData((prev) => ({ ...prev, [name]: checked }));
+//     } else {
+//       setMenuData((prev) => ({ ...prev, [name]: value }));
+//     }
+//   };
+
+//   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+//     const file = e.target.files?.[0];
+//     if (file) {
+//       setImageFile(file);
+//       const previewUrl = URL.createObjectURL(file);
+//       setImagePreview(previewUrl);
+//     }
+//   };
+
+//   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+//     e.preventDefault();
+//     setIsDragOver(false);
+//     const file = e.dataTransfer.files?.[0];
+//     if (file && file.type.startsWith("image/")) {
+//       setImageFile(file);
+//       const previewUrl = URL.createObjectURL(file);
+//       setImagePreview(previewUrl);
+//     }
+//   };
+
+//   const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+//     e.preventDefault();
+//     setIsDragOver(true);
+//   };
+
+//   const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+//     e.preventDefault();
+//     setIsDragOver(false);
+//   };
+
+//   const removeImage = () => {
+//     setImageFile(null);
+//     if (imagePreview && !imagePreview.startsWith("http")) {
+//       // 새로 업로드한 이미지만 URL 해제 (기존 서버 이미지는 제외)
+//       URL.revokeObjectURL(imagePreview);
+//     }
+//     setImagePreview(null);
+//   };
+
+//   const handleOptionToggle = (option: string) => {
+//     setMenuData((prev) => ({
+//       ...prev,
+//       optionCategories: prev.optionCategories.includes(option)
+//         ? prev.optionCategories.filter((opt) => opt !== option)
+//         : [...prev.optionCategories, option],
+//     }));
+//   };
+//   const showNotification = useNotification((state) => state.showNotification);
+
+//   // 생성 mutation
+//   const createMutation = useMutation({
+//     mutationFn: (formData: FormData) => {
+//       return menuAPI.addMenu(choosedShop!.storeId, formData);
+//     },
+//     onSuccess: () => {
+//       console.log("메뉴 생성 성공:");
+//       queryClient.invalidateQueries({ queryKey: ["menu"] });
+//       onClose();
+
+//       showNotification("메뉴가 등록되었습니다", { severity: "success" });
+//     },
+//     onError: (error) => {
+//       console.error("❌ 메뉴 생성 실패:", error);
+//       showNotification("메뉴 생성 실패", { severity: "error" });
+//     },
+//   });
+
+//   // 수정 mutation
+//   const updateMutation = useMutation({
+//     mutationFn: ({ id, formData }: { id: string; formData: FormData }) => {
+//       return menuAPI.updateMenu(choosedShop!.storeId, id, formData);
+//     },
+//     onSuccess: () => {
+//       console.log("메뉴 수정 성공:");
+//       queryClient.invalidateQueries({ queryKey: ["menu"] });
+//       onClose();
+
+//       showNotification("메뉴 수정에 성공했습니다", { severity: "success" });
+//     },
+//     onError: (error) => {
+//       console.error("❌ 메뉴 수정 실패:", error);
+//       showNotification("메뉴 수정 실패", { severity: "error" });
+//     },
+//   });
+
+//   const handleSubmit = () => {
+//     const formData = new FormData();
+
+//     // JSON 데이터
+//     const requestData = {
+//       name: menuData.name,
+//       price: Number(menuData.price),
+//       description: menuData.description,
+//       categoryId: menuData.category,
+//       optionCategories: menuData.optionCategories,
+//       isSoldOut: menuData.isSoldOut,
+//     };
+
+//     formData.append(
+//       "request",
+//       new Blob([JSON.stringify(requestData)], {
+//         type: "application/json",
+//       })
+//     );
+
+//     // 새로운 이미지 파일이 있으면 추가
+//     if (imageFile) {
+//       formData.append("image", imageFile);
+//     }
+
+//     console.log("Request Data:", requestData);
+
+//     if (mode === "create") {
+//       createMutation.mutate(formData);
+//     } else if (mode === "update" && editMenu) {
+//       updateMutation.mutate({ id: editMenu.id, formData });
+//     }
+
+//     onConfirm();
+//   };
+
+//   const handleReset = () => {
+//     setMenuData({
+//       name: "",
+//       price: "",
+//       description: "",
+//       category: "",
+//       optionCategories: [],
+//       isSoldOut: false,
+//     });
+//     setImageFile(null);
+//     if (imagePreview && !imagePreview.startsWith("http")) {
+//       URL.revokeObjectURL(imagePreview);
+//     }
+//     setImagePreview(null);
+//     setIsDragOver(false);
+//   };
+
+//   const handleClose = () => {
+//     handleReset();
+//     onClose();
+//   };
+
+//   if (!isOpen) return null;
+
+//   const isLoading = createMutation.isPending || updateMutation.isPending;
+
+//   return (
+//     <div className="fixed inset-0 bg-black/50 flex justify-center items-center z-50">
+//       <div className="bg-white rounded-2xl shadow-2xl overflow-hidden max-w-2xl w-full">
+//         <div className="max-h-[90vh] overflow-y-auto scrollbar-hide">
+//           <div className="p-6">
+//             {/* 닫기 버튼 */}
+//             <button
+//               onClick={handleClose}
+//               className="absolute top-4 right-4 z-10 w-8 h-8 flex items-center justify-center hover:bg-gray-100 rounded-full transition-colors"
+//               disabled={isLoading}
+//             >
+//               <ClosedIcon />
+//             </button>
+
+//             {/* 제목 */}
+//             <h2 className="text-xl font-bold text-gray-900 text-center mb-6">
+//               {mode === "create" ? "새 메뉴 추가" : "메뉴 수정"}
+//             </h2>
+
+//             {/* 폼 내용 */}
+//             <div className="space-y-4">
+//               {/* 메뉴 이름 */}
+//               <div>
+//                 <label className="block text-sm font-medium text-gray-700 mb-2">
+//                   메뉴 이름{" "}
+//                   <span className=" text-sm font-bold text-red-600">*</span>
+//                 </label>
+//                 <input
+//                   type="text"
+//                   name="name"
+//                   value={menuData.name}
+//                   onChange={handleInputChange}
+//                   placeholder="예: 아메리카노"
+//                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
+//                   required
+//                   disabled={isLoading}
+//                 />
+//               </div>
+
+//               {/* 메뉴 가격 */}
+//               <div>
+//                 <label className="block text-sm font-medium text-gray-700 mb-2">
+//                   기본 가격 (원){" "}
+//                   <span className=" text-sm font-bold text-red-600">*</span>
+//                 </label>
+//                 <input
+//                   type="number"
+//                   name="price"
+//                   value={menuData.price}
+//                   onChange={handleInputChange}
+//                   placeholder="예: 4500"
+//                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
+//                   required
+//                   disabled={isLoading}
+//                 />
+//               </div>
+
+//               {/* 카테고리 선택 */}
+//               <div>
+//                 <label className="block text-sm font-medium text-gray-700 mb-2">
+//                   카테고리{" "}
+//                   <span className=" text-sm font-bold text-red-600">*</span>
+//                 </label>
+//                 <select
+//                   name="category"
+//                   value={menuData.category}
+//                   onChange={handleInputChange}
+//                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
+//                   required
+//                   disabled={isLoading}
+//                 >
+//                   <option value="">카테고리를 선택하세요</option>
+//                   {categories.map((category) => (
+//                     <option key={category.id} value={category.id}>
+//                       {category.name}
+//                     </option>
+//                   ))}
+//                 </select>
+//               </div>
+
+//               {/* 메뉴 설명 */}
+//               <div>
+//                 <label className="block text-sm font-medium text-gray-700 mb-2">
+//                   메뉴 설명
+//                 </label>
+//                 <textarea
+//                   name="description"
+//                   value={menuData.description}
+//                   onChange={handleInputChange}
+//                   placeholder="메뉴에 대한 간단한 설명을 입력하세요"
+//                   rows={3}
+//                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors resize-none"
+//                   disabled={isLoading}
+//                 />
+//               </div>
+
+//               {/* 메뉴 이미지 */}
+//               <div>
+//                 <label className="block text-sm font-medium text-gray-700 mb-2">
+//                   메뉴 이미지
+//                 </label>
+
+//                 {!imagePreview ? (
+//                   <div
+//                     onDrop={handleDrop}
+//                     onDragOver={handleDragOver}
+//                     onDragLeave={handleDragLeave}
+//                     className={`relative w-full h-32 border-2 border-dashed rounded-lg transition-colors cursor-pointer hover:bg-gray-50 ${
+//                       isDragOver
+//                         ? "border-blue-400 bg-blue-50"
+//                         : "border-gray-300"
+//                     } ${isLoading ? "pointer-events-none opacity-50" : ""}`}
+//                   >
+//                     <input
+//                       type="file"
+//                       accept="image/*"
+//                       onChange={handleImageChange}
+//                       className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+//                       disabled={isLoading}
+//                     />
+//                     <div className="flex flex-col items-center justify-center h-full text-gray-500">
+//                       <svg
+//                         className="w-8 h-8 mb-2"
+//                         fill="none"
+//                         stroke="currentColor"
+//                         viewBox="0 0 24 24"
+//                       >
+//                         <path
+//                           strokeLinecap="round"
+//                           strokeLinejoin="round"
+//                           strokeWidth={2}
+//                           d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+//                         />
+//                       </svg>
+//                       <p className="text-sm">
+//                         이미지를 드래그하거나 클릭해서 업로드
+//                       </p>
+//                       <p className="text-xs text-gray-400 mt-1">
+//                         JPG, PNG 파일만 가능
+//                       </p>
+//                     </div>
+//                   </div>
+//                 ) : (
+//                   <div className="relative inline-block">
+//                     <img
+//                       src={imagePreview}
+//                       alt="미리보기"
+//                       className="w-32 h-32 object-cover rounded-lg border border-gray-200"
+//                     />
+//                     <button
+//                       onClick={removeImage}
+//                       className="absolute -top-1 -right-1 w-4 h-4 bg-red-600 text-white rounded-full flex items-center justify-center hover:bg-red-600 transition-colors"
+//                       type="button"
+//                       disabled={isLoading}
+//                     >
+//                       <svg
+//                         className="w-3 h-3"
+//                         fill="none"
+//                         stroke="currentColor"
+//                         viewBox="0 0 24 24"
+//                       >
+//                         <path
+//                           strokeLinecap="round"
+//                           strokeLinejoin="round"
+//                           strokeWidth={2}
+//                           d="M6 18L18 6M6 6l12 12"
+//                         />
+//                       </svg>
+//                     </button>
+//                   </div>
+//                 )}
+//               </div>
+
+//               {/* 옵션 카테고리 */}
+//               <div>
+//                 <label className="block text-sm font-medium text-gray-700 mb-2">
+//                   적용 가능한 옵션
+//                 </label>
+//                 <div className="grid grid-cols-2 gap-2">
+//                   {optionData.map((option) => (
+//                     <label
+//                       key={option}
+//                       className={`flex items-center space-x-2 p-2 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer ${
+//                         isLoading ? "pointer-events-none opacity-50" : ""
+//                       }`}
+//                     >
+//                       <input
+//                         type="checkbox"
+//                         checked={menuData?.optionCategories?.includes(option)}
+//                         onChange={() => handleOptionToggle(option)}
+//                         className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+//                         disabled={isLoading}
+//                       />
+//                       <span className="text-sm text-gray-700">{option}</span>
+//                     </label>
+//                   ))}
+//                 </div>
+//               </div>
+//             </div>
+
+//             {/* 버튼 그룹 */}
+//             <div className="flex gap-3 justify-end mt-6 pt-4 border-t border-gray-200">
+//               <AcceptButton
+//                 onClick={handleSubmit}
+//                 className="text-sm !p-3"
+//                 disabled={
+//                   !menuData.name ||
+//                   !menuData.price ||
+//                   !menuData.category ||
+//                   isLoading
+//                 }
+//               >
+//                 {isLoading
+//                   ? mode === "create"
+//                     ? "등록 중..."
+//                     : "수정 중..."
+//                   : mode === "create"
+//                   ? "메뉴 추가"
+//                   : "메뉴 수정"}
+//               </AcceptButton>
+//               <CancelButton
+//                 onClick={handleClose}
+//                 className="text-sm !p-3"
+//                 disabled={isLoading}
+//               >
+//                 취소
+//               </CancelButton>
+//             </div>
+//           </div>
+//         </div>
+//       </div>
+//     </div>
+//   );
+// };
+
+// export default MenuFormModal;
 import ClosedIcon from "@/components/ui/icon/ClosedIcon";
 import AcceptButton from "@/components/ui/button/AcceptButton";
 import CancelButton from "@/components/ui/button/CancelButton";
@@ -29,7 +495,7 @@ const MenuFormModal: React.FC<MenuFormModalProps> = ({
     price: "",
     description: "",
     category: "",
-    optionCategories: [] as string[],
+    optionCategories: [] as string[], // 이름 배열로 유지
     isSoldOut: false,
   });
   const [imageFile, setImageFile] = useState<File | null>(null);
@@ -37,10 +503,7 @@ const MenuFormModal: React.FC<MenuFormModalProps> = ({
   const [isDragOver, setIsDragOver] = useState(false);
 
   const { choosedShop } = useShopStore();
-  const { categories } = useMenuStore();
-
-  // 옵션 카테고리 임의 목록
-  const availableOptions = ["사이즈", "온도", "시럽", "토핑"];
+  const { categories, optionCategories: optionData } = useMenuStore();
 
   // 수정 모드일 때 기존 데이터로 폼 초기화
   useEffect(() => {
@@ -50,7 +513,7 @@ const MenuFormModal: React.FC<MenuFormModalProps> = ({
         price: editMenu.price.toString(),
         description: editMenu.description,
         category: editMenu.categoryId || "",
-        optionCategories: editMenu.optionCategories,
+        optionCategories: editMenu.optionCategoryIds || [], // 기존 이름 배열 그대로 사용
         isSoldOut: editMenu.isSoldOut,
       });
 
@@ -63,13 +526,7 @@ const MenuFormModal: React.FC<MenuFormModalProps> = ({
       handleReset();
     }
   }, [mode, editMenu, isOpen]);
-  useEffect(() => {
-    console.log(menuData);
-    console.log(menuData);
-    console.log(menuData);
-    console.log(menuData);
-    console.log(menuData);
-  }, [menuData]);
+
   const handleInputChange = (
     e: React.ChangeEvent<
       HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
@@ -123,14 +580,15 @@ const MenuFormModal: React.FC<MenuFormModalProps> = ({
     setImagePreview(null);
   };
 
-  const handleOptionToggle = (option: string) => {
+  const handleOptionToggle = (optionName: string) => {
     setMenuData((prev) => ({
       ...prev,
-      optionCategories: prev.optionCategories.includes(option)
-        ? prev.optionCategories.filter((opt) => opt !== option)
-        : [...prev.optionCategories, option],
+      optionCategories: prev.optionCategories.includes(optionName)
+        ? prev.optionCategories.filter((opt) => opt !== optionName)
+        : [...prev.optionCategories, optionName],
     }));
   };
+
   const showNotification = useNotification((state) => state.showNotification);
 
   // 생성 mutation
@@ -172,13 +630,21 @@ const MenuFormModal: React.FC<MenuFormModalProps> = ({
   const handleSubmit = () => {
     const formData = new FormData();
 
+    // 이름 배열을 ID 배열로 변환
+    const optionCategoryIds = menuData.optionCategories
+      .map((optionName) => {
+        const option = optionData.find((opt) => opt.name === optionName);
+        return option?.id;
+      })
+      .filter((id) => id !== undefined);
+
     // JSON 데이터
     const requestData = {
       name: menuData.name,
       price: Number(menuData.price),
       description: menuData.description,
-      categoryId: menuData.category,
-      optionCategories: menuData.optionCategories,
+      categoryId: Number(menuData.category),
+      optionCategoryIds: JSON.stringify(optionCategoryIds), // ID 배열을 JSON 문자열로
       isSoldOut: menuData.isSoldOut,
     };
 
@@ -410,21 +876,25 @@ const MenuFormModal: React.FC<MenuFormModalProps> = ({
                   적용 가능한 옵션
                 </label>
                 <div className="grid grid-cols-2 gap-2">
-                  {availableOptions.map((option) => (
+                  {optionData.map((option) => (
                     <label
-                      key={option}
+                      key={option.id}
                       className={`flex items-center space-x-2 p-2 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer ${
                         isLoading ? "pointer-events-none opacity-50" : ""
                       }`}
                     >
                       <input
                         type="checkbox"
-                        checked={menuData?.optionCategories?.includes(option)}
-                        onChange={() => handleOptionToggle(option)}
+                        checked={menuData?.optionCategories?.includes(
+                          option.name
+                        )}
+                        onChange={() => handleOptionToggle(option.name)}
                         className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                         disabled={isLoading}
                       />
-                      <span className="text-sm text-gray-700">{option}</span>
+                      <span className="text-sm text-gray-700">
+                        {option.name}
+                      </span>
                     </label>
                   ))}
                 </div>

--- a/src/components/layout/modal/OptionFormModal.tsx
+++ b/src/components/layout/modal/OptionFormModal.tsx
@@ -36,7 +36,7 @@ export interface OptionGroupFormData {
   options: OptionFormData[];
 }
 
-interface OptionFormData {
+export interface OptionFormData {
   id?: number;
   name: string;
   price: number;

--- a/src/components/layout/modal/OptionFormModal.tsx
+++ b/src/components/layout/modal/OptionFormModal.tsx
@@ -1,0 +1,400 @@
+import React, { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  FormControl,
+  FormLabel,
+  RadioGroup,
+  FormControlLabel,
+  Radio,
+  Switch,
+  Typography,
+  Divider,
+  IconButton,
+  Box,
+  Chip,
+} from "@mui/material";
+import { Add, Delete, Edit } from "@mui/icons-material";
+import { optionCategoriesType, OptionItem } from "@/lib/store/MenuStore";
+
+interface OptionFormModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: OptionGroupFormData) => void;
+  editData?: optionCategoriesType | null;
+  isLoading?: boolean;
+}
+
+export interface OptionGroupFormData {
+  name: string;
+  required: boolean;
+  type: "SINGLE" | "MULTIPLE";
+  options: OptionFormData[];
+}
+
+interface OptionFormData {
+  id?: number;
+  name: string;
+  price: number;
+  default: boolean;
+}
+
+const OptionFormModal: React.FC<OptionFormModalProps> = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  editData,
+  isLoading = false,
+}) => {
+  const isEditMode = !!editData;
+
+  const [formData, setFormData] = useState<OptionGroupFormData>({
+    name: "",
+    required: false,
+    type: "SINGLE",
+    options: [],
+  });
+
+  const [errors, setErrors] = useState<{
+    name?: string;
+    options?: string;
+  }>({});
+
+  // 수정 모드일 때 데이터 초기화
+  useEffect(() => {
+    if (isEditMode && editData) {
+      setFormData({
+        name: editData.name,
+        required: editData.required,
+        type: editData.type,
+        options: editData.options.map((opt) => ({
+          id: opt.id,
+          name: opt.name,
+          price: opt.price,
+          default: opt.default,
+        })),
+      });
+    } else {
+      // 생성 모드일 때 초기화
+      setFormData({
+        name: "",
+        required: false,
+        type: "SINGLE",
+        options: [],
+      });
+    }
+    setErrors({});
+  }, [isEditMode, editData, isOpen]);
+
+  const handleClose = () => {
+    if (!isLoading) {
+      onClose();
+    }
+  };
+
+  const validateForm = () => {
+    const newErrors: typeof errors = {};
+
+    if (!formData.name.trim()) {
+      newErrors.name = "옵션 그룹명을 입력해주세요";
+    }
+
+    if (formData.options.length === 0) {
+      newErrors.options = "최소 1개 이상의 옵션을 추가해주세요";
+    }
+
+    // 기본 옵션 검증 (SINGLE 타입일 때만 하나의 기본값 허용)
+    if (formData.type === "SINGLE") {
+      const defaultCount = formData.options.filter((opt) => opt.default).length;
+      if (defaultCount > 1) {
+        newErrors.options =
+          "하나 선택 타입에서는 기본 옵션을 1개만 설정할 수 있습니다";
+      }
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = () => {
+    if (validateForm()) {
+      onSubmit(formData);
+    }
+  };
+
+  const addOption = () => {
+    setFormData((prev) => ({
+      ...prev,
+      options: [
+        ...prev.options,
+        {
+          name: "",
+          price: 0,
+          default: false,
+        },
+      ],
+    }));
+  };
+
+  const updateOption = (
+    index: number,
+    field: keyof OptionFormData,
+    value: any
+  ) => {
+    setFormData((prev) => ({
+      ...prev,
+      options: prev.options.map((opt, i) =>
+        i === index ? { ...opt, [field]: value } : opt
+      ),
+    }));
+  };
+
+  const removeOption = (index: number) => {
+    setFormData((prev) => ({
+      ...prev,
+      options: prev.options.filter((_, i) => i !== index),
+    }));
+  };
+
+  const handleDefaultChange = (index: number, isDefault: boolean) => {
+    if (formData.type === "SINGLE" && isDefault) {
+      // SINGLE 타입일 때는 다른 옵션들의 기본값을 false로 변경
+      setFormData((prev) => ({
+        ...prev,
+        options: prev.options.map((opt, i) => ({
+          ...opt,
+          default: i === index ? isDefault : false,
+        })),
+      }));
+    } else {
+      updateOption(index, "default", isDefault);
+    }
+  };
+
+  return (
+    <Dialog
+      open={isOpen}
+      onClose={handleClose}
+      maxWidth="md"
+      fullWidth
+      PaperProps={{
+        sx: { minHeight: "60vh" },
+      }}
+    >
+      <DialogTitle>
+        {isEditMode ? "옵션 그룹 수정" : "옵션 그룹 생성"}
+      </DialogTitle>
+
+      <DialogContent dividers>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+          {/* 기본 정보 */}
+          <Box>
+            <Typography variant="h6" gutterBottom>
+              기본 정보
+            </Typography>
+
+            <TextField
+              label="옵션 그룹명"
+              value={formData.name}
+              onChange={(e) =>
+                setFormData((prev) => ({ ...prev, name: e.target.value }))
+              }
+              error={!!errors.name}
+              helperText={errors.name}
+              fullWidth
+              margin="normal"
+              placeholder="예: 사이즈, 온도, 토핑"
+            />
+
+            <Box sx={{ display: "flex", alignItems: "center", gap: 2, mt: 2 }}>
+              <Typography>필수 선택</Typography>
+              <Switch
+                checked={formData.required}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    required: e.target.checked,
+                  }))
+                }
+              />
+              <Chip
+                label={formData.required ? "필수" : "선택"}
+                color={formData.required ? "error" : "primary"}
+                size="small"
+              />
+            </Box>
+
+            <FormControl component="fieldset" sx={{ mt: 2 }}>
+              <FormLabel component="legend">선택 타입</FormLabel>
+              <RadioGroup
+                row
+                value={formData.type}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    type: e.target.value as "SINGLE" | "MULTIPLE",
+                  }))
+                }
+              >
+                <FormControlLabel
+                  value="SINGLE"
+                  control={<Radio />}
+                  label="하나 선택"
+                />
+                <FormControlLabel
+                  value="MULTIPLE"
+                  control={<Radio />}
+                  label="다중 선택"
+                />
+              </RadioGroup>
+            </FormControl>
+          </Box>
+
+          <Divider />
+
+          {/* 옵션 목록 */}
+          <Box>
+            <Box
+              sx={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                mb: 2,
+              }}
+            >
+              <Typography variant="h6">
+                옵션 목록 ({formData.options.length}개)
+              </Typography>
+              <Button
+                startIcon={<Add />}
+                onClick={addOption}
+                variant="outlined"
+                size="small"
+              >
+                옵션 추가
+              </Button>
+            </Box>
+
+            {errors.options && (
+              <Typography color="error" variant="body2" sx={{ mb: 2 }}>
+                {errors.options}
+              </Typography>
+            )}
+
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 2,
+                maxHeight: "300px",
+                overflowY: "auto",
+              }}
+            >
+              {formData.options.map((option, index) => (
+                <Box
+                  key={index}
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 2,
+                    p: 2,
+                    border: "1px solid #e0e0e0",
+                    borderRadius: 2,
+                    backgroundColor: "#fafafa",
+                  }}
+                >
+                  <TextField
+                    label="옵션명"
+                    value={option.name}
+                    onChange={(e) =>
+                      updateOption(index, "name", e.target.value)
+                    }
+                    size="small"
+                    sx={{ flex: 1 }}
+                    placeholder="예: Small, Medium, Large"
+                  />
+
+                  <TextField
+                    label="추가 가격"
+                    type="number"
+                    value={option.price}
+                    onChange={(e) =>
+                      updateOption(
+                        index,
+                        "price",
+                        parseInt(e.target.value) || 0
+                      )
+                    }
+                    size="small"
+                    sx={{ width: 120 }}
+                    InputProps={{
+                      endAdornment: <Typography variant="body2">원</Typography>,
+                    }}
+                  />
+
+                  <Box
+                    sx={{
+                      display: "flex",
+                      flexDirection: "column",
+                      alignItems: "center",
+                      minWidth: 60,
+                    }}
+                  >
+                    <Typography variant="body2" sx={{ fontSize: "0.75rem" }}>
+                      기본값
+                    </Typography>
+                    <Switch
+                      checked={option.default}
+                      onChange={(e) =>
+                        handleDefaultChange(index, e.target.checked)
+                      }
+                      size="small"
+                    />
+                  </Box>
+
+                  <IconButton
+                    onClick={() => removeOption(index)}
+                    color="error"
+                    size="small"
+                  >
+                    <Delete />
+                  </IconButton>
+                </Box>
+              ))}
+
+              {formData.options.length === 0 && (
+                <Box
+                  sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    py: 4,
+                    color: "grey.500",
+                  }}
+                >
+                  <Typography variant="body2">옵션을 추가해주세요</Typography>
+                </Box>
+              )}
+            </Box>
+          </Box>
+        </Box>
+      </DialogContent>
+
+      <DialogActions sx={{ p: 2, gap: 1 }}>
+        <Button onClick={handleClose} disabled={isLoading}>
+          취소
+        </Button>
+        <Button onClick={handleSubmit} variant="contained" disabled={isLoading}>
+          {isLoading ? "처리중..." : isEditMode ? "수정" : "생성"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default OptionFormModal;

--- a/src/components/layout/option/OptionCard.tsx
+++ b/src/components/layout/option/OptionCard.tsx
@@ -1,0 +1,149 @@
+import { optionCategoriesType } from "@/lib/store/MenuStore";
+import React, { useState } from "react";
+import AddRoundedIcon from "@mui/icons-material/AddRounded";
+import { IconButton } from "@mui/material";
+import { Edit as EditIcon, Delete as DeleteIcon } from "@mui/icons-material";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { error } from "console";
+import { optionAPI } from "@/lib/api/option";
+import { useNotification } from "@/hooks/useNotification";
+import { useShopStore } from "@/lib/store/shopStore";
+import ConfirmModal from "../modal/ConfirmModal";
+
+interface OptionCardProps {
+  optionItem: optionCategoriesType;
+}
+
+const OptionCard: React.FC<OptionCardProps> = ({ optionItem }) => {
+  const showNotification = useNotification((state) => state.showNotification);
+  const { choosedShop } = useShopStore();
+  const queryClient = useQueryClient();
+  const [isDeleteModal, setIsDeleteModal] = useState(false);
+
+  const deleteCategoriesMutation = useMutation({
+    mutationFn: ({
+      storeId,
+      optionCategoryId,
+    }: {
+      storeId: number;
+      optionCategoryId: number;
+    }) => optionAPI.deleteOptionCategory(storeId, optionCategoryId),
+    onSuccess: () => {
+      console.log("옵션 카테고리 삭제 성공");
+      showNotification("옵션그룹 삭제 성공", { severity: "success" });
+      setIsDeleteModal(false);
+      queryClient.invalidateQueries({ queryKey: ["option"] });
+    },
+    onError: (error) => {
+      console.log("옵션 카테고리 삭제 오류", error);
+      showNotification("옵션그룹 삭제 실패", { severity: "error" });
+    },
+  });
+  const handleCategoiesDelete = () => {
+    deleteCategoriesMutation.mutate({
+      storeId: choosedShop!.storeId,
+      optionCategoryId: optionItem.id,
+    });
+  };
+  return (
+    <>
+      <div className="bg-white border border-gray-200 rounded-lg p-5 shadow-sm hover:shadow-md transition-shadow w-100">
+        {/* 카드 헤더 */}
+        <div className="flex justify-between items-start mb-4">
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900 mb-1">
+              {optionItem.name}
+            </h3>
+            <div className="flex gap-2">
+              {/* 필수/선택 태그 */}
+              <span
+                className={`px-2 py-1 text-xs font-medium rounded-full ${
+                  optionItem.required
+                    ? "bg-red-100 text-red-700"
+                    : "bg-blue-100 text-blue-700"
+                }`}
+              >
+                {optionItem.required ? "필수" : "선택"}
+              </span>
+
+              {/* 타입 태그 */}
+              <span className="px-2 py-1 text-xs font-medium rounded-full bg-gray-100 text-gray-600">
+                {optionItem.type === "SINGLE" ? "하나 선택" : "다중 선택"}
+              </span>
+            </div>
+          </div>
+
+          {/* 그룹 액션 버튼 */}
+          <div className="flex gap-1">
+            <IconButton
+              size="medium"
+              onClick={(e) => {
+                e.stopPropagation();
+              }}
+              sx={{ color: "primary.main" }}
+            >
+              <EditIcon fontSize="medium" />
+            </IconButton>
+            <IconButton
+              size="medium"
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsDeleteModal(true);
+              }}
+              sx={{ color: "error.main" }}
+            >
+              <DeleteIcon fontSize="medium" />
+            </IconButton>
+          </div>
+        </div>
+
+        {/* 옵션 리스트 */}
+        <div className="space-y-2 mb-4">
+          {optionItem.options.map((option) => {
+            return (
+              <div
+                key={option.id}
+                className="flex justify-between items-center p-3 bg-gray-50 rounded-md border-l-4 border-blue-400"
+              >
+                <div>
+                  <div className="font-medium text-gray-900 text-sm">
+                    {option.name}
+                    {option.default && (
+                      <span className="ml-2 px-1.5 py-0.5 text-xs bg-green-100 text-green-700 rounded">
+                        기본
+                      </span>
+                    )}
+                  </div>
+                  {option.price > 0 && (
+                    <div className="text-sm text-green-600 font-medium mt-1">
+                      +{option.price.toLocaleString()}원
+                    </div>
+                  )}
+                  {option.price === 0 && (
+                    <div className="text-sm text-gray-500 mt-1">+0원</div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* 옵션 추가 버튼 */}
+        <button className="w-full py-3 border-2 border-dashed border-gray-300 rounded-lg text-gray-500 text-sm hover:border-blue-400 hover:text-blue-600 transition-colors flex items-center justify-center gap-2">
+          <AddRoundedIcon sx={{ width: 16 }} />
+          옵션 추가
+        </button>
+      </div>
+      <ConfirmModal
+        isOpen={isDeleteModal}
+        onClose={() => setIsDeleteModal(false)}
+        onConfirm={handleCategoiesDelete}
+        purpose={"옵션 그룹"}
+        targetName={optionItem!.name}
+        isLoading={deleteCategoriesMutation.isPending}
+      />
+    </>
+  );
+};
+
+export default OptionCard;

--- a/src/components/layout/option/OptionManage.tsx
+++ b/src/components/layout/option/OptionManage.tsx
@@ -1,0 +1,171 @@
+"use client";
+import SearchBar from "@/components/ui/card/SearchBar";
+import { SectionTitle } from "@/components/ui/title/SectionTitle";
+import React, { useEffect, useMemo, useState } from "react";
+import ViewMode from "./ViewMode";
+import { optionAPI } from "@/lib/api/option";
+import { useShopStore } from "@/lib/store/shopStore";
+import OptionCard from "./OptionCard";
+import { useMenuStore } from "@/lib/store/MenuStore";
+import OptionFormModal, { OptionGroupFormData } from "../modal/OptionFormModal";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNotification } from "@/hooks/useNotification";
+
+const OptionManage = () => {
+  const showNotification = useNotification((state) => state.showNotification);
+  const queryClient = useQueryClient();
+  const [searchQuery, setSearchQuery] = useState(""); //검색어
+  const [chooseLabel, setChooseLabel] = useState("전체"); //전체/필수/선택
+  const [isCreateModal, setIsCreateModal] = useState(false); //생성 모달
+
+  const { optionCategories } = useMenuStore();
+  const { choosedShop } = useShopStore();
+
+  const filteredData = useMemo(() => {
+    let filtered = optionCategories;
+    // 필수/선택 필터링
+    if (chooseLabel === "필수")
+      filtered = filtered.filter((option) => option.required);
+    else if (chooseLabel === "선택")
+      filtered = filtered.filter((option) => !option.required);
+
+    //  검색어 필터링
+    if (searchQuery.trim()) {
+      filtered = filtered.filter((option) => {
+        const groupNameMatch = option.name
+          .toLowerCase()
+          .includes(searchQuery.toLowerCase());
+        const optionNameMatch = option.options.some((opt) =>
+          opt.name.toLowerCase().includes(searchQuery.toLowerCase())
+        );
+
+        return groupNameMatch || optionNameMatch;
+      });
+    }
+
+    return filtered;
+  }, [optionCategories, searchQuery, chooseLabel]);
+
+  const createCategoriesMutation = useMutation({
+    mutationFn: ({
+      storeId,
+      data,
+    }: {
+      storeId: number;
+      data: OptionGroupFormData;
+    }) => optionAPI.addOptions(storeId, data),
+    onSuccess: () => {
+      console.log("옵션 카테고리 생성 성공");
+      showNotification("옵션그룹 생성 성공", { severity: "success" });
+      queryClient.invalidateQueries({ queryKey: ["option"] });
+      setIsCreateModal(false);
+    },
+    onError: (error) => {
+      console.log("옵션 카테고리 생성 오류", error);
+      showNotification("옵션그룹 생성 실패", { severity: "error" });
+    },
+  });
+  const handleCreateSubmit = (data: OptionGroupFormData) => {
+    createCategoriesMutation.mutate({
+      storeId: choosedShop!.storeId,
+      data,
+    });
+  };
+  const openCreateModal = () => {
+    console.log("클릭");
+    setIsCreateModal(true);
+  };
+  return (
+    <>
+      <div className="bg-white rounded-xl p-6 shadow-sm mb-6">
+        <SectionTitle
+          title={"옵션 그룹"}
+          subText={
+            "사이즈, 온도, 토핑 등의 옵션 그룹을 만들고 개별 옵션들을 추가하세요"
+          }
+          buttonText="+ 그룹 추가"
+          buttonClassName="px-3 py-2 text-sm"
+          buttonClick={openCreateModal}
+        />
+
+        {/* 검색바 및 뷰모드 슬라이드 그룹 */}
+        <div className="bg-white rounded-xl p-6 mb-6">
+          <div className="flex flex-col sm:flex-row gap-4 items-center justify-between">
+            <div className="flex-1">
+              <SearchBar
+                searchQuery={searchQuery}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setSearchQuery(e.target.value)
+                }
+                count={0}
+                placeholder={"옵션 관련 정보로 검색해 보세요"}
+              />
+            </div>
+            <ViewMode
+              chooseLabel={chooseLabel}
+              setChooseLabel={setChooseLabel}
+            />
+          </div>
+        </div>
+
+        <div
+          className="grid gap-6 
+      grid-cols-1 
+      sm:grid-cols-1 
+      md:grid-cols-2 
+      xl:grid-cols-3 
+      2xl:grid-cols-4
+      auto-rows-fr"
+        >
+          {filteredData.map((item) => (
+            <OptionCard key={item.id} optionItem={item} />
+          ))}
+        </div>
+
+        {/* 빈 상태 */}
+        {filteredData.length === 0 && (
+          <div className="text-center py-12">
+            <div className="w-16 h-16 mx-auto mb-4 bg-gray-100 rounded-full flex items-center justify-center">
+              <svg
+                className="w-8 h-8 text-gray-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+                />
+              </svg>
+            </div>
+            <h3 className="text-lg font-medium text-gray-900 mb-2">
+              옵션 그룹이 없습니다
+            </h3>
+            <p className="text-gray-500 mb-4">
+              첫 번째 옵션 그룹을 만들어 보세요
+            </p>
+            <button
+              className="px-4 py-2 bg-gradient-to-r from-brand-main to-brand-dark text-white rounded-lg hover:shadow-lg transition-shadow"
+              onClick={() => {
+                openCreateModal();
+              }}
+            >
+              + 그룹 추가
+            </button>
+          </div>
+        )}
+      </div>
+      {/* 생성 모달 */}
+      <OptionFormModal
+        isOpen={isCreateModal}
+        onClose={() => setIsCreateModal(false)}
+        onSubmit={handleCreateSubmit}
+        isLoading={createCategoriesMutation.isPending}
+      />
+    </>
+  );
+};
+
+export default OptionManage;

--- a/src/components/layout/option/ViewMode.tsx
+++ b/src/components/layout/option/ViewMode.tsx
@@ -1,0 +1,57 @@
+"use client";
+import React from "react";
+interface ViewModeProps {
+  chooseLabel: string;
+  setChooseLabel: (label: string) => void;
+}
+const ViewMode: React.FC<ViewModeProps> = ({ chooseLabel, setChooseLabel }) => {
+  const viewmode = [
+    { order: 1, name: "전체" },
+    { order: 2, name: "필수" },
+    { order: 3, name: "선택" },
+  ];
+  const handleChooseLabel = (order: number, name: string) => {
+    console.log(order, name);
+    setChooseLabel(name);
+  };
+  // 현재 선택된 아이템의 인덱스 찾기
+  const selectedIndex = viewmode.findIndex((item) => item.name === chooseLabel);
+
+  // 각 탭의 너비와 간격을 고려한 위치 계산
+  const getSliderPosition = () => {
+    const tabWidth = 56;
+    const gap = 12;
+    const padding = 8;
+
+    return padding + selectedIndex * (tabWidth + gap);
+  };
+  return (
+    <div className="relative">
+      <div className="flex rounded-md shadow-sm p-2 gap-3">
+        {/* 슬라이더 배경 - 텍스트 뒤쪽에 배치 */}
+        <div
+          className="absolute top-2 w-14 h-9 bg-gradient-to-r from-brand-main to-brand-dark rounded-md shadow-sm transition-all duration-500 ease-in-out z-0"
+          style={{
+            left: `${getSliderPosition()}px`,
+          }}
+        />
+
+        {viewmode.map((item, index) => (
+          <div
+            key={item.order}
+            className={`relative z-10 px-3 py-1.5 text-md rounded-md transition-colors w-14 text-center ${
+              chooseLabel === item.name
+                ? "text-white font-medium"
+                : "text-gray-600 hover:text-gray-900"
+            }`}
+            onClick={() => handleChooseLabel(index, item.name)}
+          >
+            {item.name}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ViewMode;

--- a/src/components/ui/card/MenuCard.tsx
+++ b/src/components/ui/card/MenuCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 import ConfirmModal from "@/components/layout/modal/ConfirmModal";
 import MenuFormModal from "@/components/layout/modal/MenuFormModal";
-import { MenuItem } from "@/lib/store/MenuStore";
+import { MenuItem, useMenuStore } from "@/lib/store/MenuStore";
 
 import React, { useState } from "react";
 
@@ -24,8 +24,11 @@ const MenuCard: React.FC<MenuCardProps> = ({
     onDelete(item.id);
     setDeleteModalOpen(false);
   };
-
-  console.log("옵션 카테고리", item);
+  const { optionCategories: optionData } = useMenuStore();
+  const findOptionName = (id: string) => {
+    const result = optionData.find((ele) => ele.id === Number(id));
+    return result?.name || null;
+  };
   return (
     <>
       <div className="bg-white rounded-xl p-5 shadow-sm border border-gray-100 hover:shadow-md transition-all duration-200 hover:transform hover:-translate-y-1">
@@ -54,7 +57,7 @@ const MenuCard: React.FC<MenuCardProps> = ({
         </div>
 
         {/* 메뉴 정보 */}
-        <div className="mb-4 h-20">
+        <div className="mb-8 h-20">
           <div className="flex items-start justify-between mb-2">
             <h3 className="text-lg font-semibold text-gray-900 line-clamp-1">
               {item.name}
@@ -64,20 +67,20 @@ const MenuCard: React.FC<MenuCardProps> = ({
             </span>
           </div>
 
-          <p className="text-sm text-gray-600 line-clamp-2 mb-3">
+          <p className="text-sm text-gray-600 line-clamp-2 mb-5 whitespace-nowrap overflow-hidden text-ellipsis">
             {item.description}
           </p>
 
           {/* 옵션 카테고리 */}
           {item?.optionCategoryIds?.length > 0 ? (
             <div className="mb-3">
-              <div className="flex flex-wrap gap-1">
+              <div className="flex flex-nowrap gap-2 overflow-x-auto">
                 {item.optionCategoryIds.map((option, index) => (
                   <span
                     key={index}
-                    className="inline-block bg-gray-100 text-gray-700 px-2 py-1 rounded-md text-xs"
+                    className="flex-shrink-0  inline-block bg-gray-100 text-gray-700 px-2 py-1 rounded-md text-xs"
                   >
-                    {option}
+                    {findOptionName(option)}
                   </span>
                 ))}
               </div>

--- a/src/components/ui/card/MenuCard.tsx
+++ b/src/components/ui/card/MenuCard.tsx
@@ -24,6 +24,8 @@ const MenuCard: React.FC<MenuCardProps> = ({
     onDelete(item.id);
     setDeleteModalOpen(false);
   };
+
+  console.log("옵션 카테고리", item);
   return (
     <>
       <div className="bg-white rounded-xl p-5 shadow-sm border border-gray-100 hover:shadow-md transition-all duration-200 hover:transform hover:-translate-y-1">
@@ -67,10 +69,10 @@ const MenuCard: React.FC<MenuCardProps> = ({
           </p>
 
           {/* 옵션 카테고리 */}
-          {item?.optionCategories?.length > 0 ? (
+          {item?.optionCategoryIds?.length > 0 ? (
             <div className="mb-3">
               <div className="flex flex-wrap gap-1">
-                {item.optionCategories.map((option, index) => (
+                {item.optionCategoryIds.map((option, index) => (
                   <span
                     key={index}
                     className="inline-block bg-gray-100 text-gray-700 px-2 py-1 rounded-md text-xs"

--- a/src/lib/api/option.ts
+++ b/src/lib/api/option.ts
@@ -1,0 +1,33 @@
+import { OptionGroupFormData } from "@/components/layout/modal/OptionFormModal";
+import api from "./api";
+
+export const optionAPI = {
+  getAllOptions: async (storeId: number) => {
+    const response = await api.get(`/menu/${storeId}/option`);
+    console.log("옵션 전체 조회", response.data);
+    return response.data;
+  },
+  addOptions: async (storeId: number, data: OptionGroupFormData) => {
+    const response = await api.post(`menu/${storeId}/option`, data);
+    console.log("옵션 생성", response.data);
+    return response.data;
+  },
+  deleteOptionCategory: async (storeId: number, optionCategoryId: number) => {
+    const response = await api.delete(
+      `/menu/${storeId}/option/${optionCategoryId}`
+    );
+    console.log("옵션 카테고리 삭제", response.data);
+    return response;
+  },
+  deleteOption: async (
+    storeId: number,
+    optionCategoryId: number,
+    optionId: number
+  ) => {
+    const response = await api.delete(
+      `/menu/${storeId}/option/${optionCategoryId}/${optionId}`
+    );
+    console.log("옵션 카테고리 삭제", response.data);
+    return response;
+  },
+};

--- a/src/lib/api/option.ts
+++ b/src/lib/api/option.ts
@@ -12,6 +12,18 @@ export const optionAPI = {
     console.log("옵션 생성", response.data);
     return response.data;
   },
+  editOptios: async (
+    storeId: number,
+    optionCategoryId: number,
+    data: OptionGroupFormData
+  ) => {
+    const response = await api.put(
+      `menu/${storeId}/option/${optionCategoryId}`,
+      data
+    );
+    console.log("옵션 수정", response.data);
+    return response.data;
+  },
   deleteOptionCategory: async (storeId: number, optionCategoryId: number) => {
     const response = await api.delete(
       `/menu/${storeId}/option/${optionCategoryId}`

--- a/src/lib/api/option.ts
+++ b/src/lib/api/option.ts
@@ -8,7 +8,7 @@ export const optionAPI = {
     return response.data;
   },
   addOptions: async (storeId: number, data: OptionGroupFormData) => {
-    const response = await api.post(`menu/${storeId}/option`, data);
+    const response = await api.post(`/menu/${storeId}/option`, data);
     console.log("옵션 생성", response.data);
     return response.data;
   },
@@ -18,7 +18,7 @@ export const optionAPI = {
     data: OptionGroupFormData
   ) => {
     const response = await api.put(
-      `menu/${storeId}/option/${optionCategoryId}`,
+      `/menu/${storeId}/option/${optionCategoryId}`,
       data
     );
     console.log("옵션 수정", response.data);

--- a/src/lib/store/MenuStore.ts
+++ b/src/lib/store/MenuStore.ts
@@ -17,22 +17,38 @@ interface CategoryType {
   displayOrder: number; // 카테고리 표시 순서
 }
 
+export interface optionCategoriesType {
+  id: number;
+  name: string;
+  options: OptionItem[];
+  required: boolean;
+  type: "SINGLE" | "MULTIPLE";
+}
+export interface OptionItem {
+  default: boolean;
+  id: number;
+  name: string;
+  price: number;
+}
 interface MenuStore {
   // 데이터
   categories: CategoryType[];
   menus: Record<string, MenuItem[]>; // 카테고리별 메뉴 객체로 변경
   lastDisplayOrder: number; // 카테고리 생성시 맨 뒤 숫자
+  optionCategories: optionCategoriesType[];
 
   // 액션
   setCategories: (categories: CategoryType[]) => void;
   setMenus: (menus: Record<string, MenuItem[]>) => void; // 타입 변경
   clearMenuData: () => void;
+  setOptionCategories: (optionCategories: optionCategoriesType[]) => void;
 }
 
 export const useMenuStore = create<MenuStore>((set, get) => ({
   categories: [],
-  menus: {}, // 빈 객체로 초기화
+  menus: {},
   lastDisplayOrder: 0,
+  optionCategories: [],
 
   setCategories: (categories: CategoryType[]) => {
     const lastOrder =
@@ -48,6 +64,9 @@ export const useMenuStore = create<MenuStore>((set, get) => ({
     set({
       categories: [],
       menus: {},
+      optionCategories: [],
       lastDisplayOrder: 0,
     }),
+  setOptionCategories: (optionCategories: optionCategoriesType[]) =>
+    set({ optionCategories }),
 }));

--- a/src/lib/store/MenuStore.ts
+++ b/src/lib/store/MenuStore.ts
@@ -6,7 +6,7 @@ export interface MenuItem {
   price: number; // 메뉴 기본 가격
   description: string; // 메뉴 설명
   imageUrl: string; // 메뉴 이미지 URL
-  optionCategories: string[]; // 적용 가능한 옵션명 종류
+  optionCategoryIds: string[]; // 적용 가능한 옵션명 종류
   isSoldOut: boolean; // 품절 여부
   categoryId?: string;
 }

--- a/src/lib/store/MenuStore.ts
+++ b/src/lib/store/MenuStore.ts
@@ -42,6 +42,7 @@ interface MenuStore {
   setMenus: (menus: Record<string, MenuItem[]>) => void; // 타입 변경
   clearMenuData: () => void;
   setOptionCategories: (optionCategories: optionCategoriesType[]) => void;
+  updateCategories: (updatedCategories: CategoryType[]) => void; //카테고리 드래그 드롭 순서 변경
 }
 
 export const useMenuStore = create<MenuStore>((set, get) => ({
@@ -69,4 +70,15 @@ export const useMenuStore = create<MenuStore>((set, get) => ({
     }),
   setOptionCategories: (optionCategories: optionCategoriesType[]) =>
     set({ optionCategories }),
+  updateCategories: (updatedCategories: CategoryType[]) => {
+    const lastOrder =
+      updatedCategories.length > 0
+        ? Math.max(...updatedCategories.map((cat) => cat.displayOrder))
+        : 0;
+
+    set({
+      categories: updatedCategories,
+      lastDisplayOrder: lastOrder,
+    });
+  },
 }));


### PR DESCRIPTION
# feat(#10): 메뉴 관리 대시보드 & 옵션관리 대시보드 CRUD 및 api 연결

- 메뉴 서비스 등록에 맞는 메뉴 관리 대시보드 및 옵션 관리 대시보드 전반적인 개발 진행

## 작업내용

- 메뉴 관리 대시보드 구현
- 옵션 관리 대시보드 구현
- 메뉴 store에 카테고리, 메뉴, 옵션 구축
- 카테고리 관련 기능 구현 &api 연결
- 메뉴 관련 기능 구현 &api 연결
- 옵션 관련 기능 구현 &api 연결

## 이미지 첨부

<img width="1927" height="923" alt="image" src="https://github.com/user-attachments/assets/3d1bc6d1-7e0c-4930-b3b6-3532bd8ed36f" />
<img width="1907" height="930" alt="image" src="https://github.com/user-attachments/assets/2de34b87-21ed-4fad-8293-7b749d24fb48" />
<img width="1904" height="930" alt="image" src="https://github.com/user-attachments/assets/a6eb74df-86e1-40ec-9f95-38d97943a35e" />

## 관련이슈

Closes #9
Closes #10 
