### PR TITLE
fix(#43): 데이터 0인 라벨 표시 제거

### DIFF
--- a/src/components/layout/dashboard/CategoryChart.tsx
+++ b/src/components/layout/dashboard/CategoryChart.tsx
@@ -126,6 +126,7 @@ const CategoryChart = () => {
           size: 12,
         },
         formatter: (value: number, context: Context) => {
+          if (value === 0) return null;
           const labels = context.chart.data.labels as string[];
           return labels[context.dataIndex];
         },


### PR DESCRIPTION
# fix(#43): 데이터 0인 라벨 표시 제거

- 카테고리별 통계 내부 데이터가 0인데도 라벨이 표시되는 문제 해결

## 이미지 첨부

<img width="446" height="489" alt="image" src="https://github.com/user-attachments/assets/98488034-9183-4de0-89f0-119ad3e8133c" />

## 관련이슈

Closes #43
